### PR TITLE
createElements: allow for selectors

### DIFF
--- a/packages/createElements/package.json
+++ b/packages/createElements/package.json
@@ -18,7 +18,8 @@
         "@toolkip/primitive-helpers": "^2.0.0",
         "@toolkip/shared-types": "^2.0.0",
         "@toolkip/style-helpers": "^2.0.0",
-        "@toolkip/style-libraries": "^2.0.0"
+        "@toolkip/style-libraries": "^2.0.0",
+        "@toolkip/model": "^2.0.0"
     },
     "scripts": {
         "compile": "tsc -p tsconfig.json",

--- a/packages/createElements/src/__tests__/createElement.test.ts
+++ b/packages/createElements/src/__tests__/createElement.test.ts
@@ -1,6 +1,7 @@
 import { createElement } from "..";
 import { IDrawable } from "@toolkip/shared-types";
 import { StandardElement } from "@toolkip/shared-types";
+import { MObject, select } from '@toolkip/model';
 
 describe('basic element creation', () => {
     it('creates a basic div', () => {
@@ -21,6 +22,24 @@ describe('basic element creation', () => {
     it('creates an element with several classnames', () => {
         const elem = createElement({ cls: ['hello', 'world'] });
         expect(elem.className).toEqual('hello world');
+    })
+
+    it('creates an element with the specified content', () => {
+        const elem = createElement({ content: 'test content' });
+        expect(elem.innerHTML).toEqual('test content');
+
+        const elem2 = createElement({ innerText: 'innertext' });
+        expect(elem2.innerText).toEqual('innertext');
+    })
+
+    it('creates an element with the specified attribute', () => {
+        const elem = createElement({
+            type: 'a',
+            attr: { 
+                'href': 'https://kipprice.com'
+            }
+        });
+        expect(elem.getAttribute('href')).toEqual('https://kipprice.com');
     })
 
     it('creates an element with a child element', () => {
@@ -63,6 +82,75 @@ describe('basic element creation', () => {
         expect(clicked).toBeTruthy();
     })
 })
+
+describe('selectable testing', () => {
+    interface ISimpleModel { name: string, age: number }
+
+    const setupModel = () => {
+        const model = new MObject<ISimpleModel>({ name: 'Big Bird', age: 11 });
+        return model;
+    }
+
+    const setupStringSelector = (model: MObject<ISimpleModel>) => {
+        const selector = select<ISimpleModel, string>(
+            model, 
+            (data: ISimpleModel) => data.name && data.name.replace(" ", "_")
+        )
+        return selector;
+    }
+    it('allows for selectors to be set as IDs', () => {
+        const model = setupModel();
+        const selector = setupStringSelector(model);
+
+        const elem = createElement({
+            id: selector
+        });
+
+        expect(elem.id).toEqual('Big_Bird');
+        model.set('name', 'Oscar');
+        expect(elem.id).toEqual('Oscar');
+    })
+
+    it('allows for selectors to be set as class names', () => {
+        const model = setupModel();
+        const selector = setupStringSelector(model);
+
+        const elem = createElement({
+            cls: selector
+        })
+
+        expect(elem.className).toEqual('Big_Bird');
+        model.set('name', 'Oscar');
+        expect(elem.className).toEqual('Oscar');
+    })
+
+    it('allows for selectors to be set as content items', () => {
+        const model = setupModel();
+        const selector = setupStringSelector(model);
+
+        const elem = createElement({
+            content: selector
+        })
+
+        expect(elem.innerHTML).toEqual('Big_Bird');
+        model.set('name', 'Oscar');
+        expect(elem.innerHTML).toEqual('Oscar');
+    })
+
+    it('allows for attributes to be set as content items', () => {
+        const model = setupModel();
+        const selector = select<ISimpleModel, string>(model, (m) => `https://google.com/${m.age}` );
+
+        const elem = createElement({
+            type: 'a',
+            attr: { 'href': selector }
+        })
+
+        expect(elem.getAttribute('href')).toEqual('https://google.com/11');
+        model.set('age', 8);
+        expect(elem.getAttribute('href')).toEqual('https://google.com/8');
+    })
+});
 
 class FakeDrawable implements IDrawable {
     public draw() { return null; }

--- a/packages/createElements/src/__tests__/createElement.test.ts
+++ b/packages/createElements/src/__tests__/createElement.test.ts
@@ -150,6 +150,28 @@ describe('selectable testing', () => {
         model.set('age', 8);
         expect(elem.getAttribute('href')).toEqual('https://google.com/8');
     })
+
+    it('allows for a generic selector', () => {
+        const model = setupModel();
+        const selector = setupStringSelector(model);
+
+        const elem = createElement({
+            selector: {
+                selector, 
+                applyCb: ({ value }, elem) => {
+                    if (value.indexOf('_') !== -1) {
+                        elem.style.backgroundColor = 'rgb(50, 50, 50)';
+                    } else {
+                        elem.style.backgroundColor = 'rgb(100, 100, 100)';
+                    }
+                }
+            }
+        });
+
+        expect(elem.style.backgroundColor).toEqual('rgb(50, 50, 50)');
+        model.set('name', 'Oscar');
+        expect(elem.style.backgroundColor).toEqual('rgb(100, 100, 100)');
+    })
 });
 
 class FakeDrawable implements IDrawable {

--- a/packages/createElements/src/_interfaces.ts
+++ b/packages/createElements/src/_interfaces.ts
@@ -1,14 +1,18 @@
 import { TypedClassDefinition, IStandardStyles } from '@toolkip/style-helpers';
 import { IKeyValPair, IDictionary, IConstructor } from '@toolkip/object-helpers';
 import { StandardElement, IDrawable, DrawableElement } from '@toolkip/shared-types';
-import { BoundEvalFunction } from '@toolkip/binding';
-import { Selector } from '@toolkip/model';
+import { Selector, ModelEventFullPayload } from '@toolkip/model';
 
-export type ISelectableValue<T> = T | Selector<any, T, any, any>;
+export type SelectableValue<T> = T | Selector<any, T, any, any>;
+
+export interface ElemSelector<I = any, O = any> { 
+    selector: Selector<I, O, any, any>, 
+    applyCb: (payload: ModelEventFullPayload<any, O>, elem: StandardElement) => void 
+}
 
 export type IAttribute = IKeyValPair<string> | string | number;
 export interface IAttributes {
-    [key: string]: ISelectableValue<IAttribute>;
+    [key: string]: SelectableValue<IAttribute>;
 }
 
 export type IChild<T extends IKeyedElems = IKeyedElems> = 
@@ -49,30 +53,30 @@ export interface IElemDefinition<T extends IKeyedElems = IKeyedElems> {
     key?: keyof T;
 
     /** Id to use for the element */
-    id?: ISelectableValue<string>;
+    id?: SelectableValue<string>;
 
     /** CSS class to use for the element */
-    cls?: ISelectableValue<ClassName | IClassDefinition>;
+    cls?: SelectableValue<ClassName | IClassDefinition>;
 
     /** the type of HTML element we are creating */
     type?: keyof HTMLElementTagNameMap | keyof SVGElementTagNameMap;
 
     /** content that should be added to the element */
-    content?: ISelectableValue<string>;
-    innerText?: ISelectableValue<string>;
-    innerHTML?: ISelectableValue<string>;
+    content?: SelectableValue<string>;
+    innerText?: SelectableValue<string>;
+    innerHTML?: SelectableValue<string>;
 
     /** content that should specifically be added before the children of this element */
-    before_content?: ISelectableValue<string>;
+    before_content?: SelectableValue<string>;
 
     /** content that should specifically be added after the children of this element */
-    after_content?: ISelectableValue<string>;
+    after_content?: SelectableValue<string>;
 
     /** any additional attributes that should be applied to this element */
     attr?: IAttributes;
 
     /** any specific styles to apply to this element */
-    style?: ISelectableValue<TypedClassDefinition>;
+    style?: SelectableValue<TypedClassDefinition>;
 
     /** any children that should be added for this element */
     children?: IChild<T>[];
@@ -91,6 +95,9 @@ export interface IElemDefinition<T extends IKeyedElems = IKeyedElems> {
 
     /** determine whether this element should be able to receive focus */
     focusable?: boolean;
+
+    /** allow for a selector to apply generally to this element */
+    selector?: ElemSelector;
 }
 
 /**

--- a/packages/createElements/src/_interfaces.ts
+++ b/packages/createElements/src/_interfaces.ts
@@ -2,10 +2,13 @@ import { TypedClassDefinition, IStandardStyles } from '@toolkip/style-helpers';
 import { IKeyValPair, IDictionary, IConstructor } from '@toolkip/object-helpers';
 import { StandardElement, IDrawable, DrawableElement } from '@toolkip/shared-types';
 import { BoundEvalFunction } from '@toolkip/binding';
+import { Selector } from '@toolkip/model';
+
+export type ISelectableValue<T> = T | Selector<any, T, any, any>;
 
 export type IAttribute = IKeyValPair<string> | string | number;
 export interface IAttributes {
-    [key: string]: IAttribute;
+    [key: string]: ISelectableValue<IAttribute>;
 }
 
 export type IChild<T extends IKeyedElems = IKeyedElems> = 
@@ -14,8 +17,8 @@ export type IChild<T extends IKeyedElems = IKeyedElems> =
     IDrawable;
 
 export interface IClassDefinition { name: ClassName, styles: IStandardStyles }
-export type ClassName = string | string[];
 
+export type ClassName = string | string[];
 
 export type IKeyedElems = IDictionary<DrawableElement>;
 
@@ -46,28 +49,30 @@ export interface IElemDefinition<T extends IKeyedElems = IKeyedElems> {
     key?: keyof T;
 
     /** Id to use for the element */
-    id?: string;
+    id?: ISelectableValue<string>;
 
     /** CSS class to use for the element */
-    cls?: ClassName | IClassDefinition;
+    cls?: ISelectableValue<ClassName | IClassDefinition>;
 
     /** the type of HTML element we are creating */
     type?: keyof HTMLElementTagNameMap | keyof SVGElementTagNameMap;
 
     /** content that should be added to the element */
-    content?: string;
+    content?: ISelectableValue<string>;
+    innerText?: ISelectableValue<string>;
+    innerHTML?: ISelectableValue<string>;
 
     /** content that should specifically be added before the children of this element */
-    before_content?: string;
+    before_content?: ISelectableValue<string>;
 
     /** content that should specifically be added after the children of this element */
-    after_content?: string;
+    after_content?: ISelectableValue<string>;
 
     /** any additional attributes that should be applied to this element */
     attr?: IAttributes;
 
     /** any specific styles to apply to this element */
-    style?: TypedClassDefinition;
+    style?: ISelectableValue<TypedClassDefinition>;
 
     /** any children that should be added for this element */
     children?: IChild<T>[];
@@ -81,17 +86,11 @@ export interface IElemDefinition<T extends IKeyedElems = IKeyedElems> {
     /** if we're creating a namespaced element, allow for specifying it */
     namespace?: string;
 
-    /** determine whether this element should be able to receive focus */
-    focusable?: boolean;
-
-    /** allow HTML contents to be bound dynamically */
-    boundContent?: BoundEvalFunction<string>;
-
-    /** builds a custom tooltip in lieu of the standard title */
-    tooltip?: string;
-
     /** allow the function to spin up a drawable instead of an element (will still apply classes & the like) */
     drawable?: IConstructor<IDrawable> | (() => IDrawable);
+
+    /** determine whether this element should be able to receive focus */
+    focusable?: boolean;
 }
 
 /**

--- a/packages/model/src/_typeguards/specific.ts
+++ b/packages/model/src/_typeguards/specific.ts
@@ -5,6 +5,8 @@ import { MPrimitive, MDate } from '../primitiveModels';
 import { Primitive } from '@toolkip/shared-types';
 import { MArray, MManager } from '../arrayModels';
 import { IIdentifiable } from '@toolkip/identifiable';
+import { Selector } from '../helpers/selectors';
+import { ISelector } from '../_shared/_interfaces';
 
 export const isPrimitiveModel = <T extends Primitive = Primitive>(test: any): test is MPrimitive<T> => {
     if (test instanceof MPrimitive) { return true; }
@@ -31,7 +33,12 @@ export const isManagerModel = <T extends IIdentifiable>(test: any): test is MMan
     return false;
 }
 
-export function isIdentifiableModel(model: any): model is MIdentifiable<any> {
+export const isIdentifiableModel = (model: any): model is MIdentifiable<any> => {
     if (model instanceof MIdentifiable) { return true; }
+    return false;
+}
+
+export const isSelector = (test: any): test is ISelector<any, any> => {
+    if (test instanceof Selector) { return true; }
     return false;
 }

--- a/packages/model/src/helpers/selectors.ts
+++ b/packages/model/src/helpers/selectors.ts
@@ -165,7 +165,7 @@ export class Selector<I, O, X, K> implements ISelector<I, O, X, K> {
  * 
  * @returns The created selector 
  */
-export const select = <I, O, X, K>(
+export const select = <I, O, X = any, K = any>(
     listenable: Selectable<I>, 
     processor?: SelectorFunc<I, O>, 
     filters?: SelectorFilters<I>

--- a/packages/model/src/index.ts
+++ b/packages/model/src/index.ts
@@ -1,9 +1,11 @@
 export * from './_shared';
+export * from './_typeguards';
 export * from './abstractClasses';
 export * from './primitiveModels';
 export * from './objectModels';
 export * from './arrayModels';
 export * from './helpers';
+export * from './transforms';
 
 import { setupModelWrapping } from './helpers/modelFactory';
 setupModelWrapping();

--- a/packages/styleHelpers/src/css.ts
+++ b/packages/styleHelpers/src/css.ts
@@ -136,6 +136,17 @@ export function hasClass(elem: HTMLElement | IDrawable, cls: string): boolean {
   return true;
 };
 
+export function clearClass(elem: DrawableElement): void {
+  if (!elem) { return; }
+  let e: DrawableElement;
+  if (isDrawable(elem)) {
+    e = elem.base;
+  } else {
+    e = elem;
+  }
+  e.setAttribute("class", "");
+}
+
 /**
  * setProperty
  * ----------------------------------------------------------------------------


### PR DESCRIPTION
Now, instead of only handling a certain number of fields with dynamic elements, all created elements will have the option of using selectors to generate the appropriate data for a particular field. 

This also removes some out of date options within `createElement`